### PR TITLE
Install binary during install step

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,3 +36,4 @@ if (require.main === module) {
 }
 
 module.exports = main;
+module.exports.bin = bin;

--- a/install.js
+++ b/install.js
@@ -1,5 +1,10 @@
 const { bin } = require('./index.js');
 
+// install.js is executed during the npm installation step.
+// To re-use BinWrapper logic, and limit changes, we force BinWrapper to
+// execute "saucectl --version".
+// So we are 100% sure that the saucectl binary will be available for the next
+// execution.
 async function install () {
   console.info('Fetching saucectl binary');
   bin.run(['--version'])

--- a/install.js
+++ b/install.js
@@ -1,0 +1,21 @@
+const { bin } = require('./index.js');
+
+async function install () {
+  console.info('Fetching saucectl binary');
+  bin.run(['--version'])
+    .then(() => {
+      console.info(`Installation succeed`);
+      process.exit(0);
+    })
+    .catch((e) => {
+      console.error(`Installation failed: ${e}`);
+      console.error(`Check that you have access to https://github.com/saucelabs/saucectl/releases\n\n`);
+      process.exit(1);
+    });
+}
+
+if (require.main === module) {
+	install();
+}
+
+module.exports = install;

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "bin": "index.js",
   "scripts": {
     "clean": "rimraf coverage bin",
+    "install": "node install.js",
     "release": "npm run release:patch",
     "release:patch": "np patch",
     "release:minor": "np minor",


### PR DESCRIPTION
Fetch binary during installation rather that on first use.

Success:
```
 ➭ npm install ../node-saucectl

> saucectl@0.31.3 install /Users/user/Projects/tmp/node_modules/saucectl
> node install.js

Fetching saucectl binary
Installation succeed
+ saucectl@0.31.3
updated 1 package and audited 148 packages in 1.641s

6 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities

➭
```

Failure:

```
 ➭ npm install ../node-saucectl

> saucectl@0.31.3 install /Users/user/Projects/tmp/node_modules/saucectl
> node install.js

Fetching saucectl binary
Installation failed: RequestError: self signed certificate
Check that you have access to https://github.com/saucelabs/saucectl/releases


npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! saucectl@0.31.3 install: `node install.js`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the saucectl@0.31.3 install script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/user/.npm/_logs/2021-03-08T21_19_06_792Z-debug.log
 ➭
```