### PR TITLE
Move from allowlist to denylist

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,8 +1,6 @@
 .*
 __tests__
-/*.js
-!index.js
-!install.js
+jest.config.js
 package-lock.json
 coverage
 bin


### PR DESCRIPTION
To avoid missing files in the npm packages, convert the allowlist to denylist for `*.js` files.