### PR TITLE
Use GITHUB_TOKEN if available

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,3 +18,15 @@ jobs:
           node-version: 16
       - run: npm install
       - run: npm test
+
+  deploy-with-github_token:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+      - run: npm install
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+      - run: npm test

--- a/index.js
+++ b/index.js
@@ -8,6 +8,14 @@ const defaultBinInstallBase = 'https://github.com/saucelabs/saucectl/releases/do
 const binWrapper = (binInstallURL = null, binInstallBase = null) => {
     const bw = new BinWrapper();
 
+    if (process.env.GITHUB_TOKEN) {
+        bw.httpOptions({
+            headers: {
+                authorization: `Bearer ${process.env.GITHUB_TOKEN}`,
+            }
+        });
+    }
+
     const base = binInstallBase || defaultBinInstallBase;
 
     let sources = [

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "homepage": "https://github.com/saucelabs/node-saucectl#readme",
   "dependencies": {
-    "@saucelabs/bin-wrapper": "~0.1.2"
+    "@saucelabs/bin-wrapper": "~0.2.0"
   },
   "devDependencies": {
     "eslint": "^6.8.0",


### PR DESCRIPTION
## Proposed changes

To avoid hitting the rate limit set by Github for unauthenticated request, rely on `GITHUB_TOKEN` to authenticate the request.

Relies on https://github.com/saucelabs/bin-wrapper/pull/4