### PR TITLE
Rely on dynamic version instead of snapshots

### DIFF
--- a/__tests__/__snapshots__/main.test.js.snap
+++ b/__tests__/__snapshots__/main.test.js.snap
@@ -1,46 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`main .binWrapper should create a binary wrapper 1`] = `
-[MockFunction] {
-  "calls": [
-    [
-      "https://github.com/saucelabs/saucectl/releases/download/v0.120.0/saucectl_0.120.0_mac_arm64.tar.gz",
-      "darwin",
-      "arm64",
-    ],
-  ],
-  "results": [
-    {
-      "type": "return",
-      "value": undefined,
-    },
-  ],
-}
-`;
-
 exports[`main .binWrapper should respect the SAUCECTL_INSTALL_BINARY wrapper 1`] = `
 [MockFunction] {
   "calls": [
     [
       "http://some-fake-url",
-      "darwin",
-      "arm64",
-    ],
-  ],
-  "results": [
-    {
-      "type": "return",
-      "value": undefined,
-    },
-  ],
-}
-`;
-
-exports[`main .binWrapper should respect the SAUCECTL_INSTALL_BINARY_MIRROR wrapper 1`] = `
-[MockFunction] {
-  "calls": [
-    [
-      "https://some-fake-mirror-url/v0.120.0/saucectl_0.120.0_mac_arm64.tar.gz",
       "darwin",
       "arm64",
     ],

--- a/__tests__/main.test.js
+++ b/__tests__/main.test.js
@@ -2,6 +2,7 @@ jest.mock('child_process')
 const main = require('../');
 const childProcess = require('child_process');
 const { EventEmitter } = require('events');
+const packageJson = require('../package.json');
 
 const { BinWrapper } = require('@saucelabs/bin-wrapper');
 jest.mock('@saucelabs/bin-wrapper');
@@ -59,7 +60,13 @@ describe('main', function () {
 		test('should create a binary wrapper', async function () {
 			await main.binWrapper();
 
-			expect(mockSrc).toMatchSnapshot();
+			expect(mockSrc.mock.calls).toEqual([
+				[
+					'https://github.com/saucelabs/saucectl/releases/download/v{{version}}/saucectl_{{version}}_mac_arm64.tar.gz'.replaceAll('{{version}}', packageJson.version),
+					'darwin',
+					'arm64',
+				]
+			]);
 		});
 		test('should respect the SAUCECTL_INSTALL_BINARY wrapper', async function () {
 			await main.binWrapper('http://some-fake-url');
@@ -70,7 +77,13 @@ describe('main', function () {
 		test('should respect the SAUCECTL_INSTALL_BINARY_MIRROR wrapper', async function () {
 			await main.binWrapper(null, 'https://some-fake-mirror-url');
 
-			expect(mockSrc).toMatchSnapshot();
+			expect(mockSrc.mock.calls).toEqual([
+				[
+					'https://some-fake-mirror-url/v{{version}}/saucectl_{{version}}_mac_arm64.tar.gz'.replaceAll('{{version}}', packageJson.version),
+					'darwin',
+					'arm64',
+				]
+			]);
 		});
 	});
 });


### PR DESCRIPTION
## Proposed changes

Introducing Snapshot made tests to be failing after the first version upgrade.
That PR solve that issue.