### PR TITLE
Update @saucelabs/bin-wrapper + Separate preRun

### DIFF
--- a/__tests__/main.test.js
+++ b/__tests__/main.test.js
@@ -47,7 +47,7 @@ describe('main', function () {
 
 	test('should run the executable', async function () {
 		const bin = {
-			run: jest.fn().mockReturnValue(Promise.resolve(true)),
+			run: jest.fn().mockReturnValue(Promise.resolve(0)),
 			path: jest.fn().mockReturnValue('/bin/saucectl')
 		}
 		await main(bin, ['bar', '--foo'])
@@ -55,6 +55,16 @@ describe('main', function () {
 		expect(childProcess.spawn).toBeCalledWith('/bin/saucectl', ['bar', '--foo'], expect.any(Object))
 		mockSpawnEventEmitter.emit('exit', 0);
 		expect(exitSpy.mock.calls).toEqual([[0]]);
+	});
+	test('should display carry the exitCode', async function () {
+		const bin = {
+			run: jest.fn().mockReturnValue(Promise.resolve(1)),
+			path: jest.fn().mockReturnValue('/bin/saucectl')
+		}
+		await main(bin, ['bar', '--foo'])
+		expect(bin.run).toBeCalledTimes(1)
+		expect(childProcess.spawn).toBeCalledWith('/bin/saucectl', ['bar', '--foo'], expect.any(Object))
+		expect(exitSpy.mock.calls).toEqual([[1]]);
 	});
 	describe('.binWrapper', function () {
 		test('should create a binary wrapper', async function () {

--- a/jest.config.js
+++ b/jest.config.js
@@ -4,9 +4,9 @@ module.exports = {
     coverageThreshold: {
 		global: {
 			branches: 66,
-			functions: 100,
+			functions: 75,
 			lines: 70,
 			statements: 70
 		}
-    }
+  }
 };

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "homepage": "https://github.com/saucelabs/node-saucectl#readme",
   "dependencies": {
-    "@saucelabs/bin-wrapper": "^0.3.1"
+    "@saucelabs/bin-wrapper": "^0.4.0"
   },
   "devDependencies": {
     "eslint": "^6.8.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "homepage": "https://github.com/saucelabs/node-saucectl#readme",
   "dependencies": {
-    "@saucelabs/bin-wrapper": "~0.2.0"
+    "@saucelabs/bin-wrapper": "^0.3.1"
   },
   "devDependencies": {
     "eslint": "^6.8.0",


### PR DESCRIPTION
## Proposed changes

- Updates `@saucelabs/bin-wrapper` to `0.4.0`.
- Make the `saucectl --version` (which is used to ensure binary is running fine) to be silent except in a case of a failure.