### PR TITLE
feat: Log SAUCECTL_INSTALL_BINARY and SAUCECTL_INSTALL_BINARY_MIRROR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ package-lock.json
 bin
 coverage
 *.tgz
+.DS_Store
+

--- a/index.js
+++ b/index.js
@@ -10,6 +10,27 @@ const defaultBinInstallBase =
 const binWrapper = (binInstallURL = null, binInstallBase = null) => {
   const bw = new BinWrapper();
 
+  if (binInstallURL) {
+    try {
+      new URL(binInstallURL);
+    } catch (e) {
+      console.error(
+        `Please ensure the provided saucectl binary source is valid: ${e}`,
+      );
+      return;
+    }
+  }
+  if (binInstallBase) {
+    try {
+      new URL(binInstallBase);
+    } catch (e) {
+      console.error(
+        `Please ensure the provided saucectl binary source mirror is valid: ${e}`,
+      );
+      return;
+    }
+  }
+
   if (process.env.GITHUB_TOKEN) {
     bw.httpOptions({
       headers: {

--- a/install.js
+++ b/install.js
@@ -29,24 +29,26 @@ async function install() {
     })
     .catch((e) => {
       console.error(`Installation failed: ${e}`);
-      const binarySource = process.env.SAUCECTL_INSTALL_BINARY;
-      const binarySourceMirror = process.env.SAUCECTL_INSTALL_BINARY_MIRROR;
-      if (binarySource) {
-        console.error(
-          `Please ensure that you have access to the URL provided by the SAUCECTL_INSTALL_BINARY environment variable: ${sanitizeURL(
-            binarySource,
-          )}.\n\n`,
-        );
-      } else if (binarySourceMirror) {
-        console.error(
-          `Please ensure that you have access to the URL provided by the SAUCECTL_INSTALL_BINARY_MIRROR environment variable: ${sanitizeURL(
-            binarySourceMirror,
-          )}.\n\n`,
-        );
-      } else {
-        console.error(
-          `Please ensure that you have access to https://github.com/saucelabs/saucectl/releases.\n\n`,
-        );
+      if (e.message.includes('AxiosError')) {
+        const binarySource = process.env.SAUCECTL_INSTALL_BINARY;
+        const binarySourceMirror = process.env.SAUCECTL_INSTALL_BINARY_MIRROR;
+        if (binarySource) {
+          console.error(
+            `Please check that you have access to the URL provided by the SAUCECTL_INSTALL_BINARY environment variable: ${sanitizeURL(
+              binarySource,
+            )}\n\n`,
+          );
+        } else if (binarySourceMirror) {
+          console.error(
+            `Please check that you have access to the URL provided by the SAUCECTL_INSTALL_BINARY_MIRROR environment variable: ${sanitizeURL(
+              binarySourceMirror,
+            )}\n\n`,
+          );
+        } else {
+          console.error(
+            `Please check that you have access to https://github.com/saucelabs/saucectl/releases\n\n`,
+          );
+        }
       }
       process.exit(1);
     });

--- a/install.js
+++ b/install.js
@@ -33,19 +33,19 @@ async function install() {
       const binarySourceMirror = process.env.SAUCECTL_INSTALL_BINARY_MIRROR;
       if (binarySource) {
         console.error(
-          `Please verify that you have access to the SAUCECTL_INSTALL_BINARY environment variable (${sanitizeURL(
+          `Please ensure that you have access to the URL provided by the SAUCECTL_INSTALL_BINARY environment variable: ${sanitizeURL(
             binarySource,
-          )}).\n\n`,
+          )}.\n\n`,
         );
       } else if (binarySourceMirror) {
         console.error(
-          `Please verify that you have access to the SAUCECTL_INSTALL_BINARY_MIRROR environment variable (${sanitizeURL(
+          `Please ensure that you have access to the URL provided by the SAUCECTL_INSTALL_BINARY_MIRROR environment variable: ${sanitizeURL(
             binarySourceMirror,
-          )}).\n\n`,
+          )}.\n\n`,
         );
       } else {
         console.error(
-          `Please verify that you have access to https://github.com/saucelabs/saucectl/releases.\n\n`,
+          `Please ensure that you have access to https://github.com/saucelabs/saucectl/releases.\n\n`,
         );
       }
       process.exit(1);

--- a/install.js
+++ b/install.js
@@ -22,6 +22,9 @@ async function install() {
     process.env.SAUCECTL_INSTALL_BINARY,
     process.env.SAUCECTL_INSTALL_BINARY_MIRROR,
   );
+  if (!bw) {
+    return;
+  }
   bw.run(['--version'])
     .then(() => {
       console.info(`Installation succeed`);

--- a/install.js
+++ b/install.js
@@ -1,5 +1,16 @@
 const { binWrapper } = require('./index.js');
 
+function sanitizeURL(inputURL) {
+  const parsedURL = new URL(inputURL);
+
+  // Remove the username and password (authentication) if present
+  parsedURL.username = '';
+  parsedURL.password = '';
+
+  // Convert the sanitized URL back to a string
+  return parsedURL.toString();
+}
+
 // install.js is executed during the npm installation step.
 // To re-use BinWrapper logic, and limit changes, we force BinWrapper to
 // execute "saucectl --version".
@@ -18,9 +29,25 @@ async function install() {
     })
     .catch((e) => {
       console.error(`Installation failed: ${e}`);
-      console.error(
-        `Check that you have access to https://github.com/saucelabs/saucectl/releases or format of the SAUCECTL_INSTALL_BINARY environment variable is correct\n\n`,
-      );
+      const binarySource = process.env.SAUCECTL_INSTALL_BINARY;
+      const binarySourceMirror = process.env.SAUCECTL_INSTALL_BINARY_MIRROR;
+      if (binarySource) {
+        console.error(
+          `Please verify that you have access to the SAUCECTL_INSTALL_BINARY environment variable (${sanitizeURL(
+            binarySource,
+          )}).\n\n`,
+        );
+      } else if (binarySourceMirror) {
+        console.error(
+          `Please verify that you have access to the SAUCECTL_INSTALL_BINARY_MIRROR environment variable (${sanitizeURL(
+            binarySourceMirror,
+          )}).\n\n`,
+        );
+      } else {
+        console.error(
+          `Please verify that you have access to https://github.com/saucelabs/saucectl/releases.\n\n`,
+        );
+      }
       process.exit(1);
     });
 }


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
Given `SAUCECTL_INSTALL_BINARY` set. Error msg:

```
Fetching saucectl binary
Installation failed: Error: failed to download: AxiosError: Request failed with status code 404
Please check that you have access to the URL provided by the SAUCECTL_INSTALL_BINARY environment variable: https://example.com/test.
```

Given `SAUCECTL_INSTALL_BINARY_MIRROR` set. Error msg:
```
Fetching saucectl binary
Installation failed: Error: failed to download: AxiosError: Request failed with status code 404
Please check that you have access to the URL provided by the SAUCECTL_INSTALL_BINARY_MIRROR environment variable: https://example.com/test
```

Given not set customized source. Error msg:
```
Fetching saucectl binary
Installation failed: Error: failed to download: Error: getaddrinfo ENOTFOUND github.com
Please check that you have access to https://github.com/saucelabs/saucectl/releases
```