### PR TITLE
fix: Skip download and installation saucectl on Sauce

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,14 @@ To install `saucectl` using NPM just run:
 $ npm i -g saucectl
 ```
 
+The command should be globally available:
+
+```sh
+$ saucectl -v
+saucectl version 0.4.0
+(build 7468a24c788b4ca4d67d50372c839edf03e5df6a)
+```
+
 __Note:__ When you run the command for the first time, it will initially download the binary. This only happens once.
 
 __Note:__ `saucectl` installation are disabled on Sauce Labs Cloud. If you wish to force the installation, set the `FORCE_INSTALL_SAUCECTL` environment variable to `true`.
@@ -21,14 +29,6 @@ If you need to download `saucectl` from a specific source, or if you are using `
 
 ```
 export SAUCECTL_INSTALL_BINARY=http://localhost:9000/saucectl_0.32.2_mac_64-bit.tar.gz
-```
-
-The command should be globally available:
-
-```sh
-$ saucectl -v
-saucectl version 0.4.0
-(build 7468a24c788b4ca4d67d50372c839edf03e5df6a)
 ```
 
 ### Install Binary from a Mirror Site

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ __Note:__ `saucectl` installation are disabled on Sauce Labs Cloud. If you wish 
 
 ### Install Binary from a Specified Source
 
-If you need to download `saucectl` from a specific source, or if you are using `npx saucectl`, set the following environment variable:
+If you want the installer to download `saucectl` from a specific source, set the following environment variable:
 
 ```
 export SAUCECTL_INSTALL_BINARY=http://localhost:9000/saucectl_0.32.2_mac_64-bit.tar.gz

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ __Note:__ When you run the command for the first time, it will initially downloa
 
 __Note:__ `saucectl` installation are disabled on Sauce Labs Cloud. If you wish to force the installation, set the `FORCE_INSTALL_SAUCECTL` environment variable to `true`.
 
-### Install from a Specified Source
+### Install Binary from a Specified Source
 
 If you need to download `saucectl` from a specific source, or if you are using `npx saucectl`, set the following environment variable:
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@ To install `saucectl` using NPM just run:
 $ npm i -g saucectl
 ```
 
+__Note:__ When you run the command for the first time, it will initially download the binary. This only happens once.
+
+__Note:__ `saucectl` installation are disabled on Sauce Labs Cloud. If you wish to force the installation, set the `FORCE_INSTALL_SAUCECTL` environment variable to `true`.
+
+### Install from a Specified Source
+
 If you need to download `saucectl` from a specific source, or if you are using `npx saucectl`, set the following environment variable:
 
 ```
@@ -24,11 +30,6 @@ $ saucectl -v
 saucectl version 0.4.0
 (build 7468a24c788b4ca4d67d50372c839edf03e5df6a)
 ```
-
-__Note:__ When you run the command for the first time, it will initially download the binary. This only happens once.
-
-__Note:__ `saucectl` installation are disabled on Sauce Labs Cloud. If you wish to force the installation, set the `FORCE_INSTALL_SAUCECTL` environment variable to `true`.
-
 
 ### Install Binary from a Mirror Site
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ saucectl version 0.4.0
 
 __Note:__ When you run the command for the first time, it will initially download the binary. This only happens once.
 
-__Note:__ `saucectl` installation is disabled on Sauce Labs Cloud. If you wish to force the installation, set the `FORCE_INSTALL_SAUCECTL` environment variable to `true`.
+__Note:__ `saucectl` installation is disabled on Sauce Labs Cloud. If you wish to force the installation, set the `SAUCECTL_FORCE_INSTALL` environment variable to `true`.
 
 ### Install Binary from a Specified Source
 

--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ saucectl version 0.4.0
 (build 7468a24c788b4ca4d67d50372c839edf03e5df6a)
 ```
 
-__Note:__ if you run the command for the first time it will initially download the binary for you. This only happens once.
+__Note:__ When you run the command for the first time, it will initially download the binary. This only happens once.
 
-__Note:__ Downloading and installation are disabled on Sauce Labs Cloud. If you wish to force the installation, set the `FORCE_INSTALL_SAUCECTL` environment variable to `true`.
+__Note:__ `saucectl` installation are disabled on Sauce Labs Cloud. If you wish to force the installation, set the `FORCE_INSTALL_SAUCECTL` environment variable to `true`.
 
 
 ### Install binary from Mirror

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Node.js wrapper for [saucectl](https://github.com/saucelabs/saucectl).
 
 ## Install
 
-To install `saucectl` using NPM just run:
+To install `saucectl` via `npm`, simply run the following command:
 
 ```sh
 $ npm i -g saucectl
@@ -41,4 +41,4 @@ SAUCECTL_INSTALL_BINARY_MIRROR=https://your-mirror-download-site.com/foo/bar npm
 
 ---
 
-For more information to `saucectl`, visit its main repository: [saucelabs/saucectl](https://github.com/saucelabs/saucectl).
+For more information about `saucectl`, visit its main repository: [saucelabs/saucectl](https://github.com/saucelabs/saucectl).

--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ saucectl version 0.4.0
 
 __Note:__ if you run the command for the first time it will initially download the binary for you. This only happens once.
 
+__Note:__ Downloading and installation are disabled on Sauce Labs Cloud. If you wish to force the installation, set the `FORCE_INSTALL_SAUCECTL` environment variable to `true`.
+
+
 ### Install binary from Mirror
 
 Use the `SAUCECTL_INSTALL_BINARY_MIRROR` env to override the default download base site (https://github.com/saucelabs/saucectl/releases/download)

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ To install `saucectl` using NPM just run:
 $ npm i -g saucectl
 ```
 
-In case you need to download `saucectl` from a known source or in case you use `npx saucectl` you can use environment variable:
+If you need to download `saucectl` from a specific source, or if you are using `npx saucectl`, set the following environment variable:
 
 ```
 export SAUCECTL_INSTALL_BINARY=http://localhost:9000/saucectl_0.32.2_mac_64-bit.tar.gz
@@ -30,9 +30,9 @@ __Note:__ When you run the command for the first time, it will initially downloa
 __Note:__ `saucectl` installation are disabled on Sauce Labs Cloud. If you wish to force the installation, set the `FORCE_INSTALL_SAUCECTL` environment variable to `true`.
 
 
-### Install binary from Mirror
+### Install Binary from a Mirror Site
 
-Use the `SAUCECTL_INSTALL_BINARY_MIRROR` env to override the default download base site (https://github.com/saucelabs/saucectl/releases/download)
+Override the default download site by setting the `SAUCECTL_INSTALL_BINARY_MIRROR` environment variable to a custom URL. The default site is [Sauce Labs saucectl releases](https://github.com/saucelabs/saucectl/releases/download).
 
 ```bash
 SAUCECTL_INSTALL_BINARY_MIRROR=https://your-mirror-download-site.com/foo/bar npm i -g saucectl

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ saucectl version 0.4.0
 
 __Note:__ When you run the command for the first time, it will initially download the binary. This only happens once.
 
-__Note:__ `saucectl` installation are disabled on Sauce Labs Cloud. If you wish to force the installation, set the `FORCE_INSTALL_SAUCECTL` environment variable to `true`.
+__Note:__ `saucectl` installation is disabled on Sauce Labs Cloud. If you wish to force the installation, set the `FORCE_INSTALL_SAUCECTL` environment variable to `true`.
 
 ### Install Binary from a Specified Source
 

--- a/install.js
+++ b/install.js
@@ -18,7 +18,7 @@ function sanitizeURL(inputURL) {
 // execution.
 async function install() {
   if (process.env.SAUCE_VM) {
-    if (!process.env.FORCE_INSTALL_SAUCECTL) {
+    if (!process.env.SAUCECTL_FORCE_INSTALL) {
       console.info('Skipping the installation of saucectl on Sauce Cloud.');
       return;
     }

--- a/install.js
+++ b/install.js
@@ -17,9 +17,11 @@ function sanitizeURL(inputURL) {
 // So we are 100% sure that the saucectl binary will be available for the next
 // execution.
 async function install() {
-  if (process.env.SAUCE_VM && process.env.FORCE_INSTALL_SAUCECTL) {
-    console.info('Skipping the installation of saucectl on Sauce Cloud.');
-    return;
+  if (process.env.SAUCE_VM) {
+    if (!process.env.FORCE_INSTALL_SAUCECTL) {
+      console.info('Skipping the installation of saucectl on Sauce Cloud.');
+      return;
+    }
   }
   console.info('Fetching saucectl binary');
   const bw = binWrapper(

--- a/install.js
+++ b/install.js
@@ -18,7 +18,7 @@ function sanitizeURL(inputURL) {
 // execution.
 async function install() {
   if (!process.env.FORCE_INSTALL_SAUCECTL && process.env.SAUCE_VM) {
-    console.info('Skipping the download and installation of saucectl.');
+    console.info('Skipping the installation of saucectl on Sauce Cloud.');
     return;
   }
   console.info('Fetching saucectl binary');
@@ -31,7 +31,7 @@ async function install() {
   }
   bw.run(['--version'])
     .then(() => {
-      console.info('Installation succeed');
+      console.info('Installation succeeded');
       process.exit(0);
     })
     .catch((e) => {

--- a/install.js
+++ b/install.js
@@ -17,7 +17,7 @@ function sanitizeURL(inputURL) {
 // So we are 100% sure that the saucectl binary will be available for the next
 // execution.
 async function install() {
-  if (!process.env.FORCE_INSTALL_SAUCECTL && process.env.SAUCE_VM) {
+  if (process.env.SAUCE_VM && process.env.FORCE_INSTALL_SAUCECTL) {
     console.info('Skipping the installation of saucectl on Sauce Cloud.');
     return;
   }

--- a/install.js
+++ b/install.js
@@ -17,6 +17,10 @@ function sanitizeURL(inputURL) {
 // So we are 100% sure that the saucectl binary will be available for the next
 // execution.
 async function install() {
+  if (!process.env.FORCE_INSTALL_SAUCECTL && process.env.SAUCE_VM) {
+    console.info('Skipping the download and installation of saucectl.');
+    return;
+  }
   console.info('Fetching saucectl binary');
   const bw = binWrapper(
     process.env.SAUCECTL_INSTALL_BINARY,
@@ -27,7 +31,7 @@ async function install() {
   }
   bw.run(['--version'])
     .then(() => {
-      console.info(`Installation succeed`);
+      console.info('Installation succeed');
       process.exit(0);
     })
     .catch((e) => {


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
Skip download and installation saucectl on Sauce.