### PR TITLE
fix: Downgrade np package

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "eslint-plugin-jest": "^28.6.0",
     "eslint-plugin-prettier": "^5.1.3",
     "jest": "^29.7.0",
-    "np": "^10.0.5",
+    "np": "8.0.4",
     "npm-run-all": "^4.1.5",
     "prettier": "^3.3.1",
     "replace-in-files-cli": "^2.2.0",


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

The `np` package has a bug in versions later than `8.0.4` which is affecting our pipeline. Downgrade to version `8.0.4` to ensure our processes continue to run smoothly.

```
✖ Error: Increment 0.178.0 should be one of patch, minor, major, prepatch, preminor, premajor, or prerelease.
    at new Version (file:///Users/tianfeng/code/node-saucectl/node_modules/np/source/version.js:70:11)
```